### PR TITLE
feat: add basic auth and admin controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/api-page/admin.html
+++ b/api-page/admin.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Admin Dashboard</title>
+  <link rel="stylesheet" href="/assets/styles.css">
+</head>
+<body>
+  <h1>Admin Dashboard</h1>
+  <div id="stats"></div>
+  <h2>Users</h2>
+  <table id="users"></table>
+  <h2>Logs</h2>
+  <ul id="logs"></ul>
+  <button id="logout">Logout</button>
+  <script>
+    const token = localStorage.getItem('token');
+    if (!token) {
+      window.location.href = '/login';
+    }
+    async function load() {
+      const headers = { Authorization: 'Bearer ' + token };
+      const statsRes = await fetch('/api/admin/stats', { headers });
+      if (!statsRes.ok) {
+        window.location.href = '/dashboard';
+        return;
+      }
+      const statsData = await statsRes.json();
+      const s = statsData.stats;
+      document.getElementById('stats').textContent = `Total Users: ${s.totalUsers} | Suspended: ${s.suspendedUsers} | Total Requests: ${s.totalRequests}`;
+      const usersRes = await fetch('/api/admin/users', { headers });
+      const usersData = await usersRes.json();
+      const table = document.getElementById('users');
+      table.innerHTML = '<tr><th>Username</th><th>Role</th><th>Suspended</th><th>Action</th></tr>';
+      usersData.users.forEach(u => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${u.username}</td><td>${u.role}</td><td class="suspended">${u.suspended}</td><td><button data-user="${u.username}" data-suspended="${u.suspended}">${u.suspended ? 'Unsuspend' : 'Suspend'}</button></td>`;
+        table.appendChild(tr);
+      });
+      table.addEventListener('click', async (e) => {
+        if (e.target.tagName === 'BUTTON') {
+          const username = e.target.getAttribute('data-user');
+          const suspended = e.target.getAttribute('data-suspended') === 'true';
+          const res = await fetch(`/api/admin/users/${username}/suspend`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + token },
+            body: JSON.stringify({ suspended: !suspended })
+          });
+          if (res.ok) {
+            e.target.textContent = suspended ? 'Suspend' : 'Unsuspend';
+            e.target.setAttribute('data-suspended', (!suspended).toString());
+            e.target.closest('tr').querySelector('.suspended').textContent = (!suspended).toString();
+          }
+        }
+      });
+      const logsRes = await fetch('/api/admin/logs', { headers });
+      const logsData = await logsRes.json();
+      const logUl = document.getElementById('logs');
+      logsData.logs.forEach(l => {
+        const li = document.createElement('li');
+        li.textContent = l;
+        logUl.appendChild(li);
+      });
+    }
+    document.getElementById('logout').addEventListener('click', () => {
+      localStorage.removeItem('token');
+      localStorage.removeItem('username');
+      window.location.href = '/login';
+    });
+    load();
+  </script>
+</body>
+</html>

--- a/api-page/dashboard.html
+++ b/api-page/dashboard.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>User Dashboard</title>
+  <link rel="stylesheet" href="/assets/styles.css">
+</head>
+<body>
+  <h1>User Dashboard</h1>
+  <p id="welcome"></p>
+  <button id="logout">Logout</button>
+  <script>
+    const token = localStorage.getItem('token');
+    if (!token) {
+      window.location.href = '/login';
+    }
+    const username = localStorage.getItem('username');
+    document.getElementById('welcome').textContent = `Welcome, ${username}`;
+    document.getElementById('logout').addEventListener('click', () => {
+      localStorage.removeItem('token');
+      localStorage.removeItem('username');
+      window.location.href = '/login';
+    });
+  </script>
+</body>
+</html>

--- a/api-page/login.html
+++ b/api-page/login.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+  <link rel="stylesheet" href="/assets/styles.css">
+</head>
+<body>
+  <h1>Login</h1>
+  <form id="loginForm">
+    <input type="text" id="username" placeholder="Username" required>
+    <input type="password" id="password" placeholder="Password" required>
+    <button type="submit">Login</button>
+  </form>
+  <p id="error" style="color:red"></p>
+  <p>Don't have an account? <a href="/register">Register</a></p>
+  <script>
+    document.getElementById('loginForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const username = document.getElementById('username').value;
+      const password = document.getElementById('password').value;
+      try {
+        const res = await fetch('/api/auth/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username, password })
+        });
+        const data = await res.json();
+        if (res.ok && data.token) {
+          localStorage.setItem('token', data.token);
+          localStorage.setItem('username', username);
+          const adminCheck = await fetch('/api/admin/stats', {
+            headers: { Authorization: 'Bearer ' + data.token }
+          });
+          if (adminCheck.ok) {
+            window.location.href = '/admin';
+          } else {
+            window.location.href = '/dashboard';
+          }
+        } else {
+          document.getElementById('error').textContent = data.error || 'Login failed';
+        }
+      } catch (err) {
+        document.getElementById('error').textContent = 'Login failed';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/api-page/register.html
+++ b/api-page/register.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Register</title>
+  <link rel="stylesheet" href="/assets/styles.css">
+</head>
+<body>
+  <h1>Register</h1>
+  <form id="registerForm">
+    <input type="text" id="username" placeholder="Username" required>
+    <input type="password" id="password" placeholder="Password" required>
+    <button type="submit">Register</button>
+  </form>
+  <p id="error" style="color:red"></p>
+  <p>Already have an account? <a href="/login">Login</a></p>
+  <script>
+    document.getElementById('registerForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const username = document.getElementById('username').value;
+      const password = document.getElementById('password').value;
+      try {
+        const res = await fetch('/api/auth/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username, password })
+        });
+        const data = await res.json();
+        if (res.ok && data.status) {
+          window.location.href = '/login';
+        } else {
+          document.getElementById('error').textContent = data.error || 'Registration failed';
+        }
+      } catch (err) {
+        document.getElementById('error').textContent = 'Registration failed';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ import cors from "cors"
 import path from "path"
 import { fileURLToPath, pathToFileURL } from "url"
 import { createRequire } from "module"
+import { logRequest } from "./src/utils/logger.js"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -19,6 +20,10 @@ app.set("json spaces", 2)
 app.use(express.json())
 app.use(express.urlencoded({ extended: false }))
 app.use(cors())
+app.use((req, res, next) => {
+  logRequest(req)
+  next()
+})
 
 app.use((req, res, next) => {
   res.setHeader("X-Content-Type-Options", "nosniff")
@@ -248,6 +253,22 @@ await loadApiRoutes()
 
 console.log(chalk.bgHex("#90EE90").hex("#333").bold(" Load Complete! ✓ "))
 console.log(chalk.bgHex("#90EE90").hex("#333").bold(` Total Routes Loaded: ${totalRoutes} `))
+
+app.get("/login", (req, res) => {
+  res.sendFile(path.join(__dirname, "api-page", "login.html"))
+})
+
+app.get("/register", (req, res) => {
+  res.sendFile(path.join(__dirname, "api-page", "register.html"))
+})
+
+app.get("/dashboard", (req, res) => {
+  res.sendFile(path.join(__dirname, "api-page", "dashboard.html"))
+})
+
+app.get("/admin", (req, res) => {
+  res.sendFile(path.join(__dirname, "api-page", "admin.html"))
+})
 
 app.get("/", (req, res) => {
   res.sendFile(path.join(__dirname, "api-page", "index.html"))

--- a/src/api/admin/stats.js
+++ b/src/api/admin/stats.js
@@ -1,0 +1,19 @@
+import { readUsers } from "../../utils/userService.js"
+import { requireAuth } from "../../utils/authTokens.js"
+import { getLogs, getStats } from "../../utils/logger.js"
+
+export default (app) => {
+  app.get("/api/admin/stats", requireAuth("admin"), (req, res) => {
+    const users = readUsers()
+    const stats = {
+      totalUsers: users.length,
+      suspendedUsers: users.filter((u) => u.suspended).length,
+      totalRequests: getStats().totalRequests,
+    }
+    res.json({ status: true, stats })
+  })
+
+  app.get("/api/admin/logs", requireAuth("admin"), (req, res) => {
+    res.json({ status: true, logs: getLogs() })
+  })
+}

--- a/src/api/admin/users.js
+++ b/src/api/admin/users.js
@@ -1,0 +1,21 @@
+import { readUsers, findUser, updateUser } from "../../utils/userService.js"
+import { requireAuth } from "../../utils/authTokens.js"
+
+export default (app) => {
+  app.get("/api/admin/users", requireAuth("admin"), (req, res) => {
+    const users = readUsers().map(({ passwordHash, ...rest }) => rest)
+    res.json({ status: true, users })
+  })
+
+  app.post("/api/admin/users/:username/suspend", requireAuth("admin"), (req, res) => {
+    const { username } = req.params
+    const { suspended } = req.body
+    const user = findUser(username)
+    if (!user) {
+      return res.status(404).json({ status: false, error: "User not found" })
+    }
+    user.suspended = !!suspended
+    updateUser(user)
+    res.json({ status: true, user: { username: user.username, suspended: user.suspended, role: user.role } })
+  })
+}

--- a/src/api/auth/login.js
+++ b/src/api/auth/login.js
@@ -1,0 +1,22 @@
+import crypto from "crypto"
+import { findUser } from "../../utils/userService.js"
+import { generateToken } from "../../utils/authTokens.js"
+
+export default (app) => {
+  app.post("/api/auth/login", (req, res) => {
+    const { username, password } = req.body
+    if (!username || !password) {
+      return res.status(400).json({ status: false, error: "Username and password required" })
+    }
+    const user = findUser(username)
+    if (!user || user.suspended) {
+      return res.status(401).json({ status: false, error: "Invalid credentials" })
+    }
+    const passwordHash = crypto.createHash("sha256").update(password).digest("hex")
+    if (user.passwordHash !== passwordHash) {
+      return res.status(401).json({ status: false, error: "Invalid credentials" })
+    }
+    const token = generateToken(user)
+    res.json({ status: true, token })
+  })
+}

--- a/src/api/auth/register.js
+++ b/src/api/auth/register.js
@@ -1,0 +1,18 @@
+import crypto from "crypto"
+import { addUser, findUser } from "../../utils/userService.js"
+
+export default (app) => {
+  app.post("/api/auth/register", (req, res) => {
+    const { username, password } = req.body
+    if (!username || !password) {
+      return res.status(400).json({ status: false, error: "Username and password required" })
+    }
+    if (findUser(username)) {
+      return res.status(409).json({ status: false, error: "User already exists" })
+    }
+    const passwordHash = crypto.createHash("sha256").update(password).digest("hex")
+    const user = { username, passwordHash, role: "user", suspended: false }
+    addUser(user)
+    res.json({ status: true, message: "User registered" })
+  })
+}

--- a/src/users.json
+++ b/src/users.json
@@ -1,0 +1,8 @@
+[
+  {
+    "username": "admin",
+    "passwordHash": "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918",
+    "role": "admin",
+    "suspended": false
+  }
+]

--- a/src/utils/authTokens.js
+++ b/src/utils/authTokens.js
@@ -1,0 +1,26 @@
+import crypto from "crypto"
+
+const tokens = new Map()
+
+export function generateToken(user) {
+  const token = crypto.randomBytes(24).toString("hex")
+  tokens.set(token, { username: user.username, role: user.role })
+  return token
+}
+
+export function verifyToken(token) {
+  return tokens.get(token)
+}
+
+export function requireAuth(role) {
+  return (req, res, next) => {
+    const authHeader = req.headers.authorization || ""
+    const token = authHeader.split(" ")[1]
+    const session = verifyToken(token)
+    if (!session || (role && session.role !== role)) {
+      return res.status(401).json({ status: false, error: "Unauthorized" })
+    }
+    req.user = session
+    next()
+  }
+}

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,18 @@
+export const logs = []
+
+export function logRequest(req) {
+  logs.push({
+    path: req.originalUrl,
+    method: req.method,
+    time: new Date().toISOString(),
+  })
+  if (logs.length > 1000) logs.shift()
+}
+
+export function getLogs() {
+  return logs
+}
+
+export function getStats() {
+  return { totalRequests: logs.length }
+}

--- a/src/utils/userService.js
+++ b/src/utils/userService.js
@@ -1,0 +1,41 @@
+import fs from "fs"
+import path from "path"
+import { fileURLToPath } from "url"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const usersFile = path.join(__dirname, "../users.json")
+
+export function readUsers() {
+  try {
+    const data = fs.readFileSync(usersFile, "utf-8")
+    return JSON.parse(data)
+  } catch (e) {
+    return []
+  }
+}
+
+export function writeUsers(users) {
+  fs.writeFileSync(usersFile, JSON.stringify(users, null, 2))
+}
+
+export function findUser(username) {
+  return readUsers().find((u) => u.username === username)
+}
+
+export function addUser(user) {
+  const users = readUsers()
+  users.push(user)
+  writeUsers(users)
+}
+
+export function updateUser(user) {
+  const users = readUsers()
+  const index = users.findIndex((u) => u.username === user.username)
+  if (index !== -1) {
+    users[index] = user
+    writeUsers(users)
+    return true
+  }
+  return false
+}


### PR DESCRIPTION
## Summary
- serve new login, registration, user dashboard, and admin dashboard pages
- implement simple UI flows for authentication and admin user management

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b787164e48327bb366d728d94afeb